### PR TITLE
Include paths separated by colons are not handled

### DIFF
--- a/lib/snailgun/server.rb
+++ b/lib/snailgun/server.rb
@@ -76,7 +76,9 @@ module Snailgun
           e << v
         end
         opts.on("-I DIR") do |v|
-          $:.unshift v
+          v.split(':').each do |value|
+            $:.unshift value
+          end
         end
         opts.on("-r LIB") do |v|
           require v


### PR DESCRIPTION
This breaks autotest when the test_helper requires are specified this way:
    require 'test_helper'
