### PR TITLE
I modified the README file's Rails example, as it would always error for me.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,7 +58,7 @@ with `snailgun -v` if you wish to be notified when it is ready.
     $ cd testapp
     $ vi config/environments/test.rb
     ... set config.cache_classes = false
-    $ snailgun
+    $ snailgun -I test
     Now entering subshell. Use 'exit' to terminate snailgun
 
     $ time RAILS_ENV=test fruby script/runner 'puts 1+2'


### PR DESCRIPTION
(From commit f9b5abd5d438b95354a5's comment.)

I am using SnailGun with ruby 1.9.2p0 (2010-08-18 revision 29036) [i686-linux] and ActiveSupport version 3.0.3. When running the README Rails example, I always will get a test_helper not found error.

A commenter on http://kresimirbojcic.com/2010/11/speeding-up-rails-testing-cycle/ pointed out that this happens in other non-SnailGun contexts, and suggested that users edit the test files. Instead, I suggest (http://blog.hoofbeats.org/post/2376252488/snailgun-test-helper-error) including the test directory when invoking snailgun.
